### PR TITLE
Update .NET version to 10.x across configurations

### DIFF
--- a/.github/workflows/main_rummisolve.yml
+++ b/.github/workflows/main_rummisolve.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
           
       - name: Build with dotnet
         run: dotnet build --configuration Release

--- a/BlazorRummiSolve.Tests/BlazorRummiSolve.Tests.csproj
+++ b/BlazorRummiSolve.Tests/BlazorRummiSolve.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/BlazorRummiSolve/BlazorRummiSolve.csproj
+++ b/BlazorRummiSolve/BlazorRummiSolve.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/RummiSolve/RummiSolve/RummiSolve.csproj
+++ b/RummiSolve/RummiSolve/RummiSolve.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
Update the GitHub workflow to bump the `.NET` version to `10.x` in the `main_rummisolve` configuration. Updated all project files to target `.NET 10.0`. These changes ensure compatibility with the latest .NET runtime.